### PR TITLE
Added support for rectangular shaped canvases

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ Try it out yourself! A [live demo](https://pixel-.herokuapp.com/) is available!
 	CANVAS_COLORS: ["#eeeeee", "red", "orange", "yellow", "green", "blue", "purple", "#614126", "white", "black"]
 	```
 
+	NOTE: The canvas size needs to be set in two places (one for the server and one for the browser). For the server set at the top of PixeServer.js, and for
+	the browser set in pixel-config.js.
+
+
 4. **(Optional)** Enable MongoDB support by creating a database with a collection named `pixels`.  
 	When running the script, make sure the `MONGODB_URI` environment variable is set. In Heroku, it's under `Settings -> Config Variables`.  
 	*Note:* If the MongoDB URI is not set, all pixel data will only be kept in memory and will not be saved after a script reload.
-	
+
 ### Deployment
 1. Run the WebSocket server.
 	```
@@ -70,11 +74,11 @@ Pixel can be manipulated with the PixelSocket class (included in `PixelSocket.js
 	* Action:	`canvasInfo`  
 		Server sends updated canvas dimensions  
 		Attributes:		'width', 'height'  
-		
+
 	* Action: `updatePixel`  
 		Server notifies the client a pixel was updated with coordinates  
 		Attributes: 'x', 'y', 'color'  
-		
+
 	* Action: `timer`  
 		Server sends the time when the next pixel can be drawn  
 		Attributes: 'time', 'type'  

--- a/src/PixelServer.js
+++ b/src/PixelServer.js
@@ -152,13 +152,13 @@ ws.on("connection", function(socket) {
             case "paint":
 
                 // Check rate limits
-                // if (remoteIP in timestamps) {
-                //     if (message_timestamp - timestamps[remoteIP] < USER_PAINT_LIMIT * 1000) {
-                //         sendTimer('toofast', USER_PAINT_LIMIT * 1000 - (message_timestamp - timestamps[remoteIP]));
-                //         sendPixelUpdate(data.x, data.y);
-                //         break;
-                //     }
-                // }
+                if (remoteIP in timestamps) {
+                    if (message_timestamp - timestamps[remoteIP] < USER_PAINT_LIMIT * 1000) {
+                        sendTimer('toofast', USER_PAINT_LIMIT * 1000 - (message_timestamp - timestamps[remoteIP]));
+                        sendPixelUpdate(data.x, data.y);
+                        break;
+                    }
+                }
 
                 if (data.x >= 0 && data.y >= 0 && data.x < CANVAS_WIDTH && data.y < CANVAS_HEIGHT) {
 

--- a/src/PixelServer.js
+++ b/src/PixelServer.js
@@ -18,7 +18,8 @@ const PORT = process.env.PORT || 3001;
 
 const MONGODB_URI = process.env.MONGODB_URI || null;
 
-/* Dimensions of the canvas */
+/* Dimensions of the canvas, these values must be the same as the ones
+set in the browser's code. */
 const CANVAS_WIDTH = process.env.CANVAS_WIDTH || 50;
 const CANVAS_HEIGHT = process.env.CANVAS_HEIGHT || 50;
 
@@ -139,10 +140,10 @@ ws.on("connection", function(socket) {
             case "refreshPixels":
                 log("Client requested pixel refresh");
 
-                var pixelArray = new Uint8Array(CANVAS_WIDTH * CANVAS_WIDTH);
+                var pixelArray = new Uint8Array(CANVAS_WIDTH * CANVAS_HEIGHT);
                 for (var x = 0; x < CANVAS_WIDTH; x++) {
                     for (var y = 0; y < CANVAS_HEIGHT; y++) {
-                        pixelArray[x + y * CANVAS_HEIGHT] = pixels[x][y]["colorID"];
+                        pixelArray[x + y * CANVAS_WIDTH] = pixels[x][y]["colorID"];
                     }
                 }
                 socket.send(pixelArray);
@@ -151,13 +152,13 @@ ws.on("connection", function(socket) {
             case "paint":
 
                 // Check rate limits
-                if (remoteIP in timestamps) {
-                    if (message_timestamp - timestamps[remoteIP] < USER_PAINT_LIMIT * 1000) {
-                        sendTimer('toofast', USER_PAINT_LIMIT * 1000 - (message_timestamp - timestamps[remoteIP]));
-                        sendPixelUpdate(data.x, data.y);
-                        break;
-                    }
-                }
+                // if (remoteIP in timestamps) {
+                //     if (message_timestamp - timestamps[remoteIP] < USER_PAINT_LIMIT * 1000) {
+                //         sendTimer('toofast', USER_PAINT_LIMIT * 1000 - (message_timestamp - timestamps[remoteIP]));
+                //         sendPixelUpdate(data.x, data.y);
+                //         break;
+                //     }
+                // }
 
                 if (data.x >= 0 && data.y >= 0 && data.x < CANVAS_WIDTH && data.y < CANVAS_HEIGHT) {
 

--- a/src/public/scripts/PixelSocket.js
+++ b/src/public/scripts/PixelSocket.js
@@ -10,7 +10,7 @@
 
 	function PixelSocket(server, autoconnect = false) {
 		this.server = server;
-		this.expectedRefreshSize = 2500;
+		this.expectedRefreshSize = undefined;
 		if (autoconnect) this.connect();
 	}
 
@@ -20,7 +20,7 @@
 
 		this.socket.onmessage = function(event) {
 
-			if (event.data.byteLength == this.expectedRefreshSize) {
+			if (event.data.byteLength && event.data.byteLength === this.expectedRefreshSize) {
 
 				if (this.refreshCallback)
 					this.refreshCallback(new Uint8Array(event.data));
@@ -63,7 +63,7 @@
 			console.log("PixelSocket opened");
 			if (this.onopen) this.onopen(event);
 			this.requestRefresh();
-			
+
 			setInterval(function() {
 				this.socket.send('{"action":"ping"}')
 			}, 15000);

--- a/src/public/scripts/PixelSocket.js
+++ b/src/public/scripts/PixelSocket.js
@@ -10,7 +10,7 @@
 
 	function PixelSocket(server, autoconnect = false) {
 		this.server = server;
-		this.expectedRefreshSize = undefined;
+		this.expectedRefreshSize = null;
 		if (autoconnect) this.connect();
 	}
 

--- a/src/public/scripts/main.js
+++ b/src/public/scripts/main.js
@@ -6,7 +6,7 @@
 
     var Pixel = window.Pixel || {};
     var CANVAS_WIDTH = Pixel.CANVAS_WIDTH;
-    var CANVAS_HEIGHT = Pixel.CANVAS_WIDTH;
+    var CANVAS_HEIGHT = Pixel.CANVAS_HEIGHT;
     var CANVAS_COLORS = Pixel.CANVAS_COLORS;
 
     var stage;                                          // EaselJS stage
@@ -35,7 +35,7 @@
         }
         for (var x = 0; x < CANVAS_WIDTH; x++) {
             for (var y = 0; y < CANVAS_HEIGHT; y++) {
-                var colorID = pixelData[x + y * CANVAS_HEIGHT];
+                var colorID = pixelData[x + y * CANVAS_WIDTH];
                 pixelMap[x][y]["shape"].graphics.beginFill(CANVAS_COLORS[colorID]).drawRect(x, y, 1, 1);
                 pixelMap[x][y]["color"] = colorID;
             }

--- a/src/public/scripts/pixel-config.js
+++ b/src/public/scripts/pixel-config.js
@@ -11,8 +11,8 @@
         PIXEL_SERVER: location.origin.replace(/^http/, 'ws'),
         CANVAS_WIDTH: 50, // The width and height must be the same as the values set for the server
         CANVAS_HEIGHT: 50,
-        CANVAS_INITIAL_ZOOM: 5,
-        CANVAS_MIN_ZOOM: 5,
+        CANVAS_INITIAL_ZOOM: 20,
+        CANVAS_MIN_ZOOM: 10,
         CANVAS_MAX_ZOOM: 40,
         CANVAS_COLORS: ["#eeeeee", "red", "orange", "yellow", "green", "blue", "purple", "#614126", "white", "black"],
         CANVAS_ELEMENT_ID: "pixelCanvas",

--- a/src/public/scripts/pixel-config.js
+++ b/src/public/scripts/pixel-config.js
@@ -9,10 +9,10 @@
     // Pixel Settings
     var Pixel = {
         PIXEL_SERVER: location.origin.replace(/^http/, 'ws'),
-        CANVAS_WIDTH: 50,
+        CANVAS_WIDTH: 50, // The width and height must be the same as the values set for the server
         CANVAS_HEIGHT: 50,
-        CANVAS_INITIAL_ZOOM: 20,
-        CANVAS_MIN_ZOOM: 10,
+        CANVAS_INITIAL_ZOOM: 5,
+        CANVAS_MIN_ZOOM: 5,
         CANVAS_MAX_ZOOM: 40,
         CANVAS_COLORS: ["#eeeeee", "red", "orange", "yellow", "green", "blue", "purple", "#614126", "white", "black"],
         CANVAS_ELEMENT_ID: "pixelCanvas",


### PR DESCRIPTION
This project is great! 

Tweaked the code to add support for non-square canvases. Also removed the need to hardcode the `expectedRefreshSize` in `PixelSocket.js` so the canvas size only needs to be specified in two places now.

Thanks for making this!